### PR TITLE
Add markdown-to-kb skill: ingest any folder of .md files as OKF raw sources

### DIFF
--- a/.claude/skills/markdown-to-kb/SKILL.md
+++ b/.claude/skills/markdown-to-kb/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: markdown-to-kb
+description: "Build an OKF (Open Knowledge Format) knowledge base from any folder of markdown files (course notes, docs, blog posts, exports, wikis). Same pipeline as the YouTube skills, but the source is markdown instead of transcripts. Free, no API key. Invoke with /markdown-to-kb <path-to-markdown-folder>"
+argument-hint: <path-to-markdown-folder>
+---
+
+# Build an OKF Knowledge Base from a Folder of Markdown Files
+
+Turn any folder of markdown files into a synthesized, cross-linked knowledge base in [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog). OKF is Google's open standard for LLM-readable knowledge bases: plain markdown + YAML frontmatter, navigated by index and relative links, no database or embeddings required. Any AI can read the output with zero setup.
+
+Unlike the `channel-to-kb-*` skills (which turn YouTube transcripts into an OKF bundle), this skill accepts **any folder of markdown files** as the source: course exports, documentation, blog archives, wiki dumps, note vaults, meeting notes, RFCs, ADRs — anything already in `.md`. It normalizes each file into an immutable `raw/<slug>.md` with OKF frontmatter, then runs the same extract → canonicalize → write → index → validate pipeline.
+
+**Trade-offs:** you skip the whole "fetch transcripts" step, but you own the input quality. Garbage-in-garbage-out applies — if your markdown lacks structure or has no natural topical grouping, the extraction pass will still work but the resulting taxonomy will be shallow.
+
+## When to use this skill
+
+Use `markdown-to-kb` when your source material is already text and you want it treated as first-class OKF sources. Good example inputs:
+
+- A folder of exported course modules (e.g. Dynamous AI Mastery lessons in markdown)
+- A dumped Substack / blog archive
+- A folder of RFCs, ADRs, or design docs
+- Exported wiki pages (any wiki, any format, as long as they are `.md`)
+- Meeting notes, retros, or postmortems
+
+If your source is a YouTube channel, use `channel-to-kb`, `channel-to-kb-ytdlp`, or `channel-to-kb-supadata` instead. If your source is markdown, use this skill.
+
+## Before you start
+
+Read the OKF contract this bundle obeys:
+1. Read `SCHEMA.md` in this repo (the maintainer contract: page types, frontmatter schemas, linking rules)
+2. Skim the [OKF SPEC](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) for the hard rules (every page needs `type` in frontmatter, `index.md` is reserved, cross-links are relative markdown paths)
+
+The key difference from the YouTube skills: source pages carry `type: source` with a `source_type: markdown` field (instead of `youtube_id` / `url` / `duration`). The provenance model is otherwise identical — every synthesized concept/entity cites the raw markdown file(s) it came from.
+
+## Step 1: Ingest markdown files
+
+```bash
+uv run .claude/skills/markdown-to-kb/scripts/ingest_markdown.py $ARGUMENTS --output-dir ./raw
+```
+
+This walks the source folder, normalizes each `.md` file (slugifies the filename, preserves the original path in frontmatter as `origin`), and writes:
+
+- `raw/<slug>.md` — the immutable copy with `type: raw-source` frontmatter (OKF-conformant)
+- `raw/manifest.json` — one entry per ingested file: `{slug, title, origin, ingested_at, sha256, source_type}`
+
+Flags:
+- `--limit N` cap the number of files (useful for a first pass on a large folder)
+- `--include "**/*.md"` glob pattern (default: `**/*.md`)
+- `--exclude "**/README.md"` glob pattern to skip boilerplate
+- `--source-name "Dynamous AI Mastery"` optional human label carried into frontmatter and later used in citations
+- `--source-url "https://dynamous.ai/"` optional canonical URL for the collection, used in `## Sources` sections
+
+Wait for the script to complete before proceeding.
+
+## Step 2: Build the OKF knowledge base
+
+Read `.claude/references/pipeline-guide.md` for the full extract → canonicalize → write → index process. It applies identically whether the raw files are YouTube transcripts or markdown docs; the only differences are:
+
+1. **Extract** — read each raw markdown file (from `raw/*.md`) instead of a transcript, extract concepts/entities/quotes as JSON to `scripts/extractions/`. When the source has headings, prefer them as chunk boundaries; fall back to ~800-word windows only when the file is flat.
+2. **Canonicalize** — merge all extractions into a frozen taxonomy (`scripts/manifest.json` + `scripts/taxonomy.json`)
+3. **Write** — write OKF concept/entity/source pages from the manifest. Source pages use the `type: source` schema with `source_type: markdown` and `origin: <original relative path>` in place of the YouTube fields; the `raw:` pointer works the same way.
+4. **Index** — build `index.md` files for each directory (OKF's navigation layer)
+5. **Validate** — run `python lint.py` to enforce OKF conformance, link integrity, and index coverage
+
+Process in batches per the guide. For folders under ~30 files, this fits in one session. For larger folders, save your extraction JSONs and resume across sessions.
+
+## Step 3: Validate OKF conformance
+
+```bash
+python lint.py
+```
+
+This enforces the OKF contract: every `.md` has `type` frontmatter (E1), every relative link resolves (E2), every page appears in its directory's `index.md` (E3), sources/raw parity (E4). Fix all errors. The knowledge base is ready when lint passes clean.
+
+## Example: ingest a Dynamous AI Mastery course export
+
+```bash
+# You have ~10 markdown files exported from a Dynamous course lesson
+uv run .claude/skills/markdown-to-kb/scripts/ingest_markdown.py ~/dynamous-export \
+  --output-dir ./raw \
+  --source-name "Dynamous AI Mastery" \
+  --source-url "https://dynamous.ai/"
+```
+
+Then follow the pipeline guide. You will end up with concept pages like `concepts/ai-second-brain.md` and `concepts/pydantic-ai-agents.md`, entity pages like `entities/tools/pydantic-ai.md`, and one `sources/<slug>.md` per lesson — all cross-linked, all citing the raw markdown they came from, all lint-clean.

--- a/.claude/skills/markdown-to-kb/scripts/ingest_markdown.py
+++ b/.claude/skills/markdown-to-kb/scripts/ingest_markdown.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""
+ingest_markdown.py — normalize a folder of markdown files into OKF `raw/` entries.
+
+Mirrors the shape of `.claude/skills/channel-to-kb/scripts/fetch_transcripts.py`
+but the input is a local folder of `.md` files instead of a YouTube channel.
+
+Each input file becomes:
+  raw/<slug>.md         # immutable copy with OKF frontmatter (type: raw-source)
+  raw/manifest.json     # append/refresh entry: {slug, title, origin, ...}
+
+Usage:
+    uv run ingest_markdown.py <source-folder> --output-dir ./raw
+    uv run ingest_markdown.py ~/dynamous-export --output-dir ./raw \\
+        --source-name "Dynamous AI Mastery" \\
+        --source-url  "https://dynamous.ai/"
+
+The script is deterministic and idempotent: re-running over the same folder
+updates the manifest in place and rewrites raw files only when their sha256
+changes.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?", re.DOTALL)
+H1_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+
+
+def slugify(text: str) -> str:
+    text = text.strip().lower()
+    text = re.sub(r"[^a-z0-9\s\-_]", "", text)
+    text = re.sub(r"[\s_]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text).strip("-")
+    return text or "untitled"
+
+
+def sha256_of(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def strip_frontmatter(text: str) -> tuple[str, str]:
+    """Return (frontmatter_text_without_fences, body). Empty frontmatter if absent."""
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return "", text
+    return m.group(1), text[m.end():]
+
+
+def infer_title(body: str, fallback: str) -> str:
+    m = H1_RE.search(body)
+    if m:
+        return m.group(1).strip()
+    return fallback.replace("-", " ").strip().title()
+
+
+def build_frontmatter(
+    *,
+    slug: str,
+    title: str,
+    origin: str,
+    ingested_at: str,
+    sha: str,
+    source_name: str | None,
+    source_url: str | None,
+) -> str:
+    lines = [
+        "---",
+        "type: raw-source",
+        "immutable: true",
+        f'title: "{title.replace(chr(34), chr(39))}"',
+        f"slug: {slug}",
+        f'origin: "{origin}"',
+        "source_type: markdown",
+    ]
+    if source_name:
+        lines.append(f'source_name: "{source_name}"')
+    if source_url:
+        lines.append(f"source_url: {source_url}")
+    lines += [
+        f"ingested_at: {ingested_at}",
+        f"sha256: {sha}",
+        "---",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def collect(source: Path, includes: list[str], excludes: list[str]) -> list[Path]:
+    seen: dict[Path, None] = {}
+    for pattern in includes:
+        for p in source.glob(pattern):
+            if p.is_file() and p.suffix.lower() == ".md":
+                seen[p.resolve()] = None
+    for pattern in excludes:
+        for p in source.glob(pattern):
+            seen.pop(p.resolve(), None)
+    return sorted(seen)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    ap.add_argument("source", help="folder of markdown files to ingest")
+    ap.add_argument("--output-dir", default="./raw", help="target directory (default: ./raw)")
+    ap.add_argument("--include", action="append", default=None,
+                    help="glob(s) to include (default: **/*.md)")
+    ap.add_argument("--exclude", action="append", default=None,
+                    help="glob(s) to exclude (repeatable)")
+    ap.add_argument("--limit", type=int, default=0, help="max files to ingest (0 = all)")
+    ap.add_argument("--source-name", default=None,
+                    help='human label for the collection, e.g. "Dynamous AI Mastery"')
+    ap.add_argument("--source-url", default=None,
+                    help="canonical URL for the collection")
+    args = ap.parse_args()
+
+    source = Path(args.source).expanduser().resolve()
+    if not source.is_dir():
+        print(f"error: source is not a directory: {source}", file=sys.stderr)
+        return 2
+
+    out = Path(args.output_dir).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+
+    includes = args.include or ["**/*.md"]
+    excludes = args.exclude or []
+    files = collect(source, includes, excludes)
+    if args.limit:
+        files = files[: args.limit]
+
+    if not files:
+        print(f"error: no markdown files matched under {source}", file=sys.stderr)
+        return 2
+
+    manifest_path = out / "manifest.json"
+    manifest: dict[str, dict] = {}
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            manifest = {}
+
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    used_slugs: set[str] = set(manifest.keys())
+    written = 0
+    unchanged = 0
+
+    for src_path in files:
+        rel = src_path.relative_to(source).as_posix()
+        raw_text = src_path.read_text(encoding="utf-8", errors="replace")
+        _, body = strip_frontmatter(raw_text)
+
+        base_slug = slugify(src_path.stem)
+        slug = base_slug
+        i = 2
+        # deterministic disambiguation by relative path if two files collide
+        if slug in used_slugs and manifest.get(slug, {}).get("origin") != rel:
+            parent_hint = slugify(src_path.parent.name) if src_path.parent != source else ""
+            candidate = f"{parent_hint}-{base_slug}" if parent_hint else f"{base_slug}-{i}"
+            while candidate in used_slugs and manifest.get(candidate, {}).get("origin") != rel:
+                i += 1
+                candidate = f"{base_slug}-{i}"
+            slug = candidate
+        used_slugs.add(slug)
+
+        title = infer_title(body, base_slug)
+        sha = sha256_of(body)
+        target = out / f"{slug}.md"
+
+        prior = manifest.get(slug)
+        if prior and prior.get("sha256") == sha and target.exists():
+            unchanged += 1
+            continue
+
+        frontmatter = build_frontmatter(
+            slug=slug,
+            title=title,
+            origin=rel,
+            ingested_at=now,
+            sha=sha,
+            source_name=args.source_name,
+            source_url=args.source_url,
+        )
+        target.write_text(frontmatter + body.lstrip("\n"), encoding="utf-8")
+        manifest[slug] = {
+            "slug": slug,
+            "title": title,
+            "origin": rel,
+            "source_type": "markdown",
+            "source_name": args.source_name,
+            "source_url": args.source_url,
+            "ingested_at": now,
+            "sha256": sha,
+        }
+        written += 1
+
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(
+        f"ingested {len(files)} file(s) from {source}: "
+        f"{written} written/updated, {unchanged} unchanged. "
+        f"manifest: {manifest_path.relative_to(Path.cwd()) if manifest_path.is_relative_to(Path.cwd()) else manifest_path}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Three Claude Code skills are included that replicate the full pipeline - just po
 | `/channel-to-kb` | pytubefix + youtube_transcript_api | None | Free | Quick setup, local machines |
 | `/channel-to-kb-ytdlp` | yt-dlp | None | Free | Most reliable, captures publish dates |
 | `/channel-to-kb-supadata` | Supadata API | Required | $17+/mo | No IP issues, AI fallback for uncaptioned videos |
+| `/markdown-to-kb` | Local folder of `.md` files | None | Free | Course exports, docs, blog archives, wiki dumps - anything already in markdown |
 
 ```bash
 # Example: build a KB from 3blue1brown's channel using yt-dlp

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -119,6 +119,8 @@ updated: 2026-07-21
 
 **Raw transcript** (`raw/<slug>.md`): `type: raw-transcript`, `immutable: true` - machine-written from the source database; never hand-edited.
 
+**Raw markdown source** (`raw/<slug>.md`): `type: raw-source`, `immutable: true` - ingested verbatim from an existing markdown file (course export, docs, blog archive, wiki dump). Carries `source_type: markdown` plus `origin` (original relative path), and optionally `source_name` / `source_url` for citation. Produced by the `markdown-to-kb` skill; the rest of the pipeline (extract -> canonicalize -> write -> index) is identical to the YouTube path.
+
 ## 5. Linking & typed edges (the load-bearing discipline)
 
 Relationships are what make this a wiki instead of a folder of notes. Rules:


### PR DESCRIPTION
## What

Adds a fourth `channel-to-kb`-style skill, **`markdown-to-kb`**, that lets the pipeline ingest **any folder of markdown files** as OKF `raw/` sources — not just YouTube transcripts.

Everything downstream of `raw/` (extract → canonicalize → write → index → validate) is unchanged; only the input surface widens.

## Why

The existing skills all assume the source is a YouTube channel. Many high-signal knowledge sources are already markdown: exported course lessons, docs sites, blog archives, ADRs, RFCs, wiki dumps, personal note vaults. Forcing them through a YouTube-shaped pipeline is awkward. This skill accepts them directly and produces the same OKF bundle shape.

Concrete driving example: a folder exported from the [Dynamous AI Mastery](https://dynamous.ai/) courses (10 modules of the AI Agent Mastery course, plus the AI Second Brain Bootcamp and Agentic Coding Course). Each lesson becomes a `raw/<slug>.md`; the extract/canonicalize passes then produce concept pages like `concepts/ai-second-brain.md`, `concepts/pydantic-ai-agents.md`, entity pages like `entities/tools/pydantic-ai.md`, and one `sources/<slug>.md` per lesson.

## Changes

- **`.claude/skills/markdown-to-kb/SKILL.md`** — user-facing skill doc, same shape as the three existing `channel-to-kb-*` skills. Includes a Dynamous invocation example.
- **`.claude/skills/markdown-to-kb/scripts/ingest_markdown.py`** — stdlib-only, `uv run`-compatible normalizer that:
  - walks a source folder (`--include` / `--exclude` globs, `--limit`)
  - slugifies each filename with deterministic collision handling
  - writes `raw/<slug>.md` with OKF frontmatter (`type: raw-source`, `immutable: true`, `source_type: markdown`, `origin: <original-relative-path>`, optional `source_name` / `source_url`, `ingested_at`, `sha256`)
  - maintains `raw/manifest.json` idempotently (sha256-gated rewrites; re-runs only touch changed files)
- **`SCHEMA.md`** — one paragraph documenting the new `raw-source` page type alongside the existing `raw-transcript` type.
- **`README.md`** — adds one row to the "Build your own" table for the new skill.

## Non-goals (kept out of this PR)

- No changes to `lint.py`, extraction/canonicalization scripts, or index builder — a raw markdown source is a drop-in substitute for a raw transcript from `raw/`'s perspective.
- No Obsidian-specific handling (wikilinks, `[[...]]`, dataview, attachments). That's the follow-up PR.
- No fetchers for remote sources (Confluence, SharePoint, GitHub docs, Substack). Those are separate skills; this one assumes the markdown is already on disk.

## Testing

Smoke-tested locally against a 3-file Dynamous-shaped fixture (2 lessons + a README that was correctly excluded). Verified: frontmatter shape, manifest structure, idempotent re-runs, slug-collision behavior. `python lint.py` on the branch reports the same pre-existing errors as `main` (skill/CLAUDE files without `type:` frontmatter) — no new lint regressions.

## Draft status

Opening as draft — happy to iterate on the frontmatter fields (`source_type` / `origin` naming), the SCHEMA wording, and whether the skill should also emit a matching `sources/<slug>.md` stub or leave that entirely to the write stage.
